### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,1 @@
+[![Board Status](https://jimmycumbicos.visualstudio.com/894a755a-79aa-45b2-9ad9-a332da174350/da028b1c-496d-431a-b616-c9ac947b2fa4/_apis/work/boardbadge/8432809d-f3fc-4f6c-b46d-0480b4914a8e)](https://jimmycumbicos.visualstudio.com/894a755a-79aa-45b2-9ad9-a332da174350/_boards/board/t/da028b1c-496d-431a-b616-c9ac947b2fa4/Microsoft.RequirementCategory)


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#85](https://jimmycumbicos.visualstudio.com/894a755a-79aa-45b2-9ad9-a332da174350/_workitems/edit/85). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.